### PR TITLE
Updated dockerfiles to work with latest ubuntu 20.04 Focal Fossa

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y openssh-server python-pip \
-      && rm -rf /var/lib/apt/lists/*
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
+	apt-get install -y openssh-server python3-pip && \
+	rm -rf /var/lib/apt/lists/*
 
 # Install python package
-RUN pip install --upgrade pip==9.0.3 && pip install netaddr deepdiff
+RUN pip3 install --upgrade pip==20.1 && \
+	pip3 install netaddr deepdiff
 
 RUN mkdir /var/run/sshd
 RUN echo 'root:screencast' | chpasswd

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -1,14 +1,13 @@
 # Use an official Python runtime as a parent image
 FROM ubuntu:latest
 
-# Install python
-RUN apt-get update && apt-get install software-properties-common -y \
-      && apt-add-repository ppa:ansible/ansible -y \
-      && apt-get update && apt-get install ansible python-pip -y \
-      && rm -rf /var/lib/apt/lists/*
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
+	apt-get install -y openssh-server python3-pip && \
+	rm -rf /var/lib/apt/lists/*
 
 # Install python package
-RUN pip install --upgrade pip==9.0.3 && pip install netaddr deepdiff
+RUN pip3 install --upgrade pip==20.1 && \
+	pip3 install ansible netaddr deepdiff
 
 # Setup SSH access for remote systems
 RUN mkdir -p /root/.ssh/


### PR DESCRIPTION
Thank you for making this docker setup. But it was failing for me with the latest ubuntu version. 

I used DEBIAN_FRONTEND=noninteractive to avoid the tzdata prompt. Also, I installed ansible through pip because they haven't updated the ppa's for ubuntu 20.04 [Missing PPA Thread](https://github.com/ansible/ansible/issues/68645). Also, I added openssh-server to the control container, because it wouldn't ping for me because ssh was missing (maybe ansible used to have a internal ssh or something). 

It's fine if you don't want to accept the PR. But I just thought I would pass along my work, so you don't have to troubleshoot it. 

Thanks again. 